### PR TITLE
bg: remove private route from password reset components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,8 +22,8 @@ function App () {
       <PublicRoute path='/register' component={WrappedRegistrationForm} />
       <PublicRoute exact path='/' component={LoginForm} />
       <PrivateRoute path='/inventory' component={Main} />
-      <PrivateRoute path='/resetpassword' component={ResetPasswordForm} />
-      <PrivateRoute path='/setnewpassword' component={SetNewPasswordForm} />
+      <Route path='/resetpassword' component={ResetPasswordForm} />
+      <Route path='/setnewpassword' component={SetNewPasswordForm} />
       <PrivateRoute path='/createstore' component={CreateStoreForm} />
       <PrivateRoute path='/addlogo' component={AddLogoForm} />
       <PrivateRoute path='/profile' component={EditProfile} />

--- a/src/App.js
+++ b/src/App.js
@@ -22,8 +22,8 @@ function App () {
       <PublicRoute path='/register' component={WrappedRegistrationForm} />
       <PublicRoute exact path='/' component={LoginForm} />
       <PrivateRoute path='/inventory' component={Main} />
-      <Route path='/resetpassword' component={ResetPasswordForm} />
-      <Route path='/setnewpassword' component={SetNewPasswordForm} />
+      <PublicRoute path='/resetpassword' component={ResetPasswordForm} />
+      <PublicRoute path='/setnewpassword' component={SetNewPasswordForm} />
       <PrivateRoute path='/createstore' component={CreateStoreForm} />
       <PrivateRoute path='/addlogo' component={AddLogoForm} />
       <PrivateRoute path='/profile' component={EditProfile} />


### PR DESCRIPTION
User can not access reset password route from the forgot password link since it is a private route

## Description
Describe change or new feature here.
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist
Remove any items which are not applicable.
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
## Link to Trello card
https://trello.com/c/zvjRoMDa/67-reset-password-forms-should-not-be-a-private-route