### PR TITLE
FX: Zoom on iPhone

### DIFF
--- a/src/less/reset.less
+++ b/src/less/reset.less
@@ -59,3 +59,23 @@ html, body {
 	font-size: 62.5%;
 	font-family: 'Lexend Deca', sans-serif;
 }
+
+input[type="color"],
+input[type="date"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="email"],
+input[type="month"],
+input[type="number"],
+input[type="password"],
+input[type="search"],
+input[type="tel"],
+input[type="text"],
+input[type="time"],
+input[type="url"],
+input[type="week"],
+select:focus,
+.ant-select-selection-selected-value,
+textarea {
+  font-size: 16px;
+}


### PR DESCRIPTION
## Description
Set minimum font size for inputs to 16px to prevent zoom on iPhone on page load.
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist
Remove any items which are not applicable.
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works .
- [ ] New and existing unit tests pass locally with my changes
## Link to Trello card
https://trello.com/c/MJHFZWMY/184-bug-app-ui-breaks-on-mobile-safari